### PR TITLE
Fix Bugzilla data retrieval

### DIFF
--- a/src/background/RemotePontoon.ts
+++ b/src/background/RemotePontoon.ts
@@ -122,7 +122,6 @@ export async function refreshData(context: {
   } else if (context.event === 'project list') {
     await updateProjectsList();
   }
-  // One failing data source must not prevent the others from being stored.
   const results = await Promise.allSettled([
     updateNotificationsData(),
     updateLatestTeamActivity(),
@@ -222,8 +221,6 @@ async function fetchBugzillaComponents(): Promise<{
   }
   const contentType = response.headers.get('content-type') ?? '';
   if (!contentType.includes('json')) {
-    // Guards against an endpoint silently starting to serve an HTML page with
-    // a 200 status, which would otherwise only surface as a JSON parse error.
     throw new Error(
       `Unexpected content type for Bugzilla components: ${contentType}`,
     );
@@ -236,7 +233,7 @@ async function updateTeam(): Promise<StorageContent['team']> {
   const [pontoonData, bugzillaComponents] = await Promise.all([
     pontoonRestClient.getTeamInfo(teamCode),
     // The Bugzilla component is only used to build a "report a bug" link, so
-    // failing to load it must not prevent the team stats from being stored.
+    // failing to load it should not prevent the team stats from being stored.
     fetchBugzillaComponents().catch((error) => {
       console.error(error);
       return undefined;

--- a/src/background/RemotePontoon.ts
+++ b/src/background/RemotePontoon.ts
@@ -122,12 +122,18 @@ export async function refreshData(context: {
   } else if (context.event === 'project list') {
     await updateProjectsList();
   }
-  await Promise.all([
+  // One failing data source must not prevent the others from being stored.
+  const results = await Promise.allSettled([
     updateNotificationsData(),
     updateLatestTeamActivity(),
     updateTeam(),
     updateTeamsList(),
   ]);
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error(result.reason);
+    }
+  }
 }
 
 async function updateNotificationsIfThereAreNew(pageContent: string) {
@@ -205,15 +211,37 @@ async function updateLatestTeamActivity() {
   }
 }
 
+async function fetchBugzillaComponents(): Promise<{
+  [code: string]: string;
+}> {
+  const response = await httpClient.fetch(bugzillaTeamComponents());
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Bugzilla components: ${response.status} ${response.statusText}`,
+    );
+  }
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('json')) {
+    // Guards against an endpoint silently starting to serve an HTML page with
+    // a 200 status, which would otherwise only surface as a JSON parse error.
+    throw new Error(
+      `Unexpected content type for Bugzilla components: ${contentType}`,
+    );
+  }
+  return (await response.json()) as { [code: string]: string };
+}
+
 async function updateTeam(): Promise<StorageContent['team']> {
   const teamCode = await getOneOption('locale_team');
-  const [pontoonData, bugzillaComponentsResponse] = await Promise.all([
+  const [pontoonData, bugzillaComponents] = await Promise.all([
     pontoonRestClient.getTeamInfo(teamCode),
-    httpClient.fetch(bugzillaTeamComponents()),
+    // The Bugzilla component is only used to build a "report a bug" link, so
+    // failing to load it must not prevent the team stats from being stored.
+    fetchBugzillaComponents().catch((error) => {
+      console.error(error);
+      return undefined;
+    }),
   ]);
-  const bugzillaComponents = (await bugzillaComponentsResponse.json()) as {
-    [code: string]: string;
-  };
 
   const team: StorageContent['team'] = {
     code: pontoonData.code,
@@ -227,7 +255,10 @@ async function updateTeam(): Promise<StorageContent['team']> {
       unreviewedStrings: pontoonData.unreviewed_strings,
       totalStrings: pontoonData.total_strings,
     },
-    bz_component: bugzillaComponents[pontoonData.code],
+    bz_component:
+      bugzillaComponents?.[pontoonData.code] ??
+      // Keep the previously known component rather than dropping the link.
+      (await getOneFromStorage('team'))?.bz_component,
   };
 
   await saveToStorage({ team });

--- a/src/background/RemotePontoon.ts
+++ b/src/background/RemotePontoon.ts
@@ -240,6 +240,7 @@ async function updateTeam(): Promise<StorageContent['team']> {
     }),
   ]);
 
+  const previousTeam = await getOneFromStorage('team');
   const team: StorageContent['team'] = {
     code: pontoonData.code,
     name: pontoonData.name,
@@ -253,9 +254,13 @@ async function updateTeam(): Promise<StorageContent['team']> {
       totalStrings: pontoonData.total_strings,
     },
     bz_component:
-      bugzillaComponents?.[pontoonData.code] ??
-      // Keep the previously known component rather than dropping the link.
-      (await getOneFromStorage('team'))?.bz_component,
+      bugzillaComponents !== undefined
+        ? bugzillaComponents[pontoonData.code]
+        : // The list failed to load: keep the previously known component
+          // rather than dropping the link, but only for the same team.
+          previousTeam?.code === pontoonData.code
+          ? previousTeam.bz_component
+          : undefined,
   };
 
   await saveToStorage({ team });

--- a/src/background/apiEndpoints.spec.ts
+++ b/src/background/apiEndpoints.spec.ts
@@ -4,7 +4,7 @@ describe('apiEndpoints', () => {
   describe('bugzillaTeamComponents', () => {
     it('returns the mozilla-l10n-query bugzilla product URL', () => {
       expect(bugzillaTeamComponents()).toBe(
-        'https://mozilla-l10n.github.io/mozilla-l10n-query/?bugzilla=product',
+        'https://mozilla-l10n.github.io/mozilla-l10n-query/api/bugzilla/product.json',
       );
     });
   });

--- a/src/background/apiEndpoints.ts
+++ b/src/background/apiEndpoints.ts
@@ -29,5 +29,8 @@ export function markAllNotificationsAsRead(baseUrl: string): string {
 }
 
 export function bugzillaTeamComponents(): string {
-  return 'https://mozilla-l10n.github.io/mozilla-l10n-query/?bugzilla=product';
+  // Link directly to the pre-generated JSON. The '?bugzilla=product' query on
+  // the site root only redirects here via client side JavaScript, which fetch()
+  // does not execute, so it would return the HTML page instead.
+  return 'https://mozilla-l10n.github.io/mozilla-l10n-query/api/bugzilla/product.json';
 }

--- a/src/background/httpClients/pontoonRestClient.spec.ts
+++ b/src/background/httpClients/pontoonRestClient.spec.ts
@@ -45,7 +45,7 @@ describe('pontoonRestClient', () => {
 
       expect(mockGetOneOption).toHaveBeenCalledWith('pontoon_base_url');
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://pontoon.example.com/api/v2/locales/cs',
+        'https://pontoon.example.com/api/v2/locales/cs/',
       );
       expect(result).toEqual(mockTeamData);
     });
@@ -62,7 +62,7 @@ describe('pontoonRestClient', () => {
       );
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://pontoon.example.com/api/v2/locales/blah',
+        'https://pontoon.example.com/api/v2/locales/blah/',
       );
     });
 

--- a/src/background/httpClients/pontoonRestClient.ts
+++ b/src/background/httpClients/pontoonRestClient.ts
@@ -33,7 +33,8 @@ function getPontoonBaseUrl(): Promise<string> {
 export const pontoonRestClient = {
   async getTeamInfo(locale_code: string): Promise<GetTeamInfoResponse> {
     const baseUrl = await getPontoonBaseUrl();
-    const response = await fetch(`${baseUrl}/api/v2/locales/${locale_code}`);
+    // Without the trailing slash Pontoon responds with a 301 redirect.
+    const response = await fetch(`${baseUrl}/api/v2/locales/${locale_code}/`);
     if (!response.ok) {
       const errorMessage = `Failed to fetch locale from Pontoon API: ${response.status} ${response.statusText}`;
       throw new Error(errorMessage);

--- a/src/background/httpClients/pontoonRestClient.ts
+++ b/src/background/httpClients/pontoonRestClient.ts
@@ -33,7 +33,6 @@ function getPontoonBaseUrl(): Promise<string> {
 export const pontoonRestClient = {
   async getTeamInfo(locale_code: string): Promise<GetTeamInfoResponse> {
     const baseUrl = await getPontoonBaseUrl();
-    // Without the trailing slash Pontoon responds with a 301 redirect.
     const response = await fetch(`${baseUrl}/api/v2/locales/${locale_code}/`);
     if (!response.ok) {
       const errorMessage = `Failed to fetch locale from Pontoon API: ${response.status} ${response.statusText}`;

--- a/src/commons/webExtensionsApi/index.ts
+++ b/src/commons/webExtensionsApi/index.ts
@@ -42,7 +42,7 @@ export interface StorageContent {
       unreviewedStrings: number;
       totalStrings: number;
     };
-    // Not every locale has a Bugzilla component.
+    // undefined is used when locale doesn't have a Bugzilla component.
     bz_component: string | undefined;
   };
   teamsList: {

--- a/src/commons/webExtensionsApi/index.ts
+++ b/src/commons/webExtensionsApi/index.ts
@@ -42,7 +42,8 @@ export interface StorageContent {
       unreviewedStrings: number;
       totalStrings: number;
     };
-    bz_component: string;
+    // Not every locale has a Bugzilla component.
+    bz_component: string | undefined;
   };
   teamsList: {
     [code: string]: string;

--- a/src/commons/webLinks.ts
+++ b/src/commons/webLinks.ts
@@ -193,7 +193,7 @@ export function newLocalizationBug({
   selectedText,
   url,
 }: {
-  team: { code: string; bz_component: string };
+  team: { code: string; bz_component: string | undefined };
   selectedText?: string;
   url?: string;
 }): string {
@@ -201,7 +201,8 @@ export function newLocalizationBug({
     .expand({
       q: {
         product: 'Mozilla Localizations',
-        component: team.bz_component,
+        // Let Bugzilla prompt for the component if it is unknown.
+        ...(team.bz_component ? { component: team.bz_component } : {}),
         short_desc:
           selectedText && url
             ? `[${

--- a/src/commons/webLinks.ts
+++ b/src/commons/webLinks.ts
@@ -201,7 +201,6 @@ export function newLocalizationBug({
     .expand({
       q: {
         product: 'Mozilla Localizations',
-        // Let Bugzilla prompt for the component if it is unknown.
         ...(team.bz_component ? { component: team.bz_component } : {}),
         short_desc:
           selectedText && url


### PR DESCRIPTION
Point directly to the JSON file, since the redirect happens via JS.

Also fail gracefully if the data doesn't load.

Fixes #1203